### PR TITLE
Removes requirement for .terraform-version

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -33,6 +33,7 @@ jobs:
           git clone --depth=1 https://github.com/tfutils/tfenv.git ~/.tfenv
           ln -sfn ~/.tfenv/bin/* /usr/local/bin
           tfenv install
+          tfenv use
       - name: Install pre-commit dependencies
         run: |
           pip install pre-commit
@@ -187,6 +188,7 @@ jobs:
           git clone --depth=1 https://github.com/tfutils/tfenv.git ~/.tfenv
           ln -sfn ~/.tfenv/bin/* /usr/local/bin
           tfenv install
+          tfenv use
       - name: Install pre-commit dependencies
         run: |
           pip install pre-commit


### PR DESCRIPTION
## Change description

Adds `tfenv use` to any GitHub Actions jobs that uses `tfenv`. This prevents a version detection error from `tfenv` when no .terraform-version file is provided in the branch being processed by GitHub actions.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> #27 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
