### PR TITLE
Checkout .pre-commit-config.yaml from default branch

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -22,7 +22,6 @@ jobs:
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3
         with:
           repository: StratusGrid/workflow-config
-          ref: ${{ env.WORKFLOW_VERSION }}
           path: workflow-config
       - name: Install Python ${{ env.PY_VERSION }}.X
         uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # tag=v4
@@ -56,7 +55,6 @@ jobs:
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3
         with:
           repository: StratusGrid/workflow-config
-          ref: ${{ env.WORKFLOW_VERSION }}
           path: workflow-config
       - name: Install Python ${{ env.PY_VERSION }}.X
         uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # tag=v4
@@ -99,7 +97,6 @@ jobs:
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3
         with:
           repository: StratusGrid/workflow-config
-          ref: ${{ env.WORKFLOW_VERSION }}
           path: workflow-config
       - name: Install Python ${{ env.PY_VERSION }}.X
         uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # tag=v4
@@ -127,7 +124,6 @@ jobs:
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3
         with:
           repository: StratusGrid/workflow-config
-          ref: ${{ env.WORKFLOW_VERSION }}
           path: workflow-config
       - name: Install Python ${{ env.PY_VERSION }}.X
         uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # tag=v4
@@ -157,7 +153,6 @@ jobs:
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3
         with:
           repository: StratusGrid/workflow-config
-          ref: ${{ env.WORKFLOW_VERSION }}
           path: workflow-config
       - name: Check if GitHub App is provided
         id: check-github-app
@@ -210,7 +205,6 @@ jobs:
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3
         with:
           repository: StratusGrid/workflow-config
-          ref: ${{ env.WORKFLOW_VERSION }}
           path: workflow-config
       - name: Install Python ${{ env.PY_VERSION }}.X
         uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # tag=v4
@@ -240,7 +234,6 @@ jobs:
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3
         with:
           repository: StratusGrid/workflow-config
-          ref: ${{ env.WORKFLOW_VERSION }}
           path: workflow-config
       - name: Install Python ${{ env.PY_VERSION }}.X
         uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # tag=v4

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,7 +6,6 @@ on:
 env:
   PY_VERSION: "3.10"
   GO_VERSION: "^1.19.0"
-  WORKFLOW_VERSION: "v0.1"
 
 jobs:
   terraform_fmt:


### PR DESCRIPTION
## Change description

Removes the explicitly defined git ref from each job in the GitHub Actions workflow config. Previously, it was referencing `v0.1` while the latest version was `v0.9.1`. This was not causing any issues as `.pre-commit-config.yaml` hasn't been updated since `v0.1` but may have led to issues in the future.

As our instructions suggest to reference the `main` branch when using this workflow configuration in your own projects, I have removed the WORKFLOW_VERSION and `ref`'s from `.pre-commit-config.yaml`. `action/checkout` should now fetch from the default branch of this repository, `main`. 

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> #29 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
