### PR TITLE
Update .pre-commit-config.yaml

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -212,6 +212,7 @@ jobs:
           exit-code: "1"
           scanners: "vuln,secret,misconfig"
           severity: "CRITICAL,HIGH"
+          skip-dirs: ".terraform/*"
 
   gitleaks:
     name: gitleaks

--- a/precommit-config/.pre-commit-config.yaml
+++ b/precommit-config/.pre-commit-config.yaml
@@ -33,6 +33,7 @@ repos:
         args:
           - --scanners=vuln,secret,misconfig
           - --severity=CRITICAL,HIGH
+          - --skip-dirs="**/.terraform"
           - ./ # last arg indicates the path/file to scan
   # Native Git PreCommit Hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
Allow the flag ignore at the module level

If we don't skip the scan in terraform downloaded modules (It's doing it twice), the ignore flag doesn't work at that level; adding it makes it work and doesn't affect any vulnerability scan in the module.


## Change description

> Description here

## Type of change
- [x] Bug fix (fixes an issue) 
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1](https://github.com/StratusGrid/workflow-config/issues/69) 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
