### PR TITLE
fix(tflint): verify aws plugin via PGP to dodge tflint init panic

### DIFF
--- a/precommit-config/.tflint.hcl
+++ b/precommit-config/.tflint.hcl
@@ -1,5 +1,12 @@
+# signature = "pgp" pins plugin verification to the legacy PGP key instead of the default
+# "auto", which prefers GitHub attestations. GitHub REST API 2026-03-10 dropped the `bundle`
+# field from attestation list responses; tflint unmarshals the resulting null into a nil
+# *bundle.Bundle without erroring and then panics dereferencing it during `tflint --init`.
+# Upstream: https://github.com/terraform-linters/tflint/issues/2591
+# Drop this line once that lands and the tflint we install carries the fix.
 plugin "aws" {
-    enabled = true
-    version = "0.40.0"
-    source  = "github.com/terraform-linters/tflint-ruleset-aws"
+    enabled   = true
+    version   = "0.40.0"
+    source    = "github.com/terraform-linters/tflint-ruleset-aws"
+    signature = "pgp"
 }


### PR DESCRIPTION
Every repo using `pre-commit.yml` is currently failing `terraform_tflint`. This is not a lint failure — `tflint --init` panics installing the aws plugin, before any linting runs.

```
Installing "aws" plugin...
Panic: runtime error: invalid memory address or nil pointer dereference
 -> 4: github.com/sigstore/sigstore-go/pkg/bundle.(*Bundle).TlogEntries: /bundle.go(300)
 -> 8: github.com/terraform-linters/tflint/plugin.(*SignatureChecker).VerifyAttestations: /signature.go(136)
 -> 9: github.com/terraform-linters/tflint/plugin.(*InstallConfig).Install: /install.go(134)
```

## Cause

Server-side, nothing in our repos changed. GitHub REST API version [2026-03-10](https://docs.github.com/en/rest/about-the-rest-api/breaking-changes?apiVersion=2026-03-10) removed the `bundle` field from attestation list responses. tflint calls that endpoint to verify the plugin, and:

1. GitHub now returns `"bundle": null`
2. tflint unmarshals `null` into a `**Bundle` — this sets the pointer nil and returns **no error**, so its own nil guard at `plugin/signature.go:133` never fires
3. `verifier.Verify(b, policy)` then calls a method on the nil receiver, and sigstore-go`s nil check dereferences it. Panic.

A latent tflint bug that only fires once the server returns null. Upstream: [terraform-linters/tflint#2591](https://github.com/terraform-linters/tflint/issues/2591) — filed 2026-07-16, still open, `master` unpatched.

## Fix

`signature = "pgp"` takes the legacy PGP verification path instead of the default `auto` (which prefers attestations). **Verification stays enabled.** tflint emits a deprecation warning about the legacy signing key; the hook still passes.

Alternatives ruled out:

- **Pinning an older tflint** — does not work. The trigger is server-side; every version taking the attestation path panics. Confirmed on v0.62.1 and v0.63.1.
- **Bumping sigstore-go** — does not work. v1.2.2 has the identical nil-receiver line. Fix must be tflint-side.
- **`signature = "none"`** — works but disables verification. Avoided; the PGP path works.

## Verification

Reproduced the exact CI panic locally with the current config, then confirmed the fix against a clean plugin dir on tflint v0.63.1 with an authenticated `GITHUB_TOKEN`:

```
Installing "aws" plugin...
The plugin was signed using a legacy PGP signing key. Please update the plugin to the latest version
Installed "aws" (source: github.com/terraform-linters/tflint-ruleset-aws, version: 0.40.0)
+ ruleset.aws (0.40.0)
```

Full CI rule set against a real `terraform/` tree: exit 0, zero findings.

`v0.40.0` release assets include `checksums.txt.sig`, so the PGP path is valid for the pinned version.

## Note for reviewers

The `Checkout precommit config` step has no `ref:`, so config is always read from this repo`s default branch — pinning the reusable workflow to a feature branch does not change which config CI uses. That is why this has to land on `main` to take effect anywhere. Consuming repos can drop a local `.tflint.hcl` as a stopgap (the `cp -r -n` no-clobber makes it win); stratusphere has one, to be removed once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
