### PR TITLE
fix(pre-commit): unbreak tflint, free disk in terraform_validate, scope trivy

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -2,6 +2,12 @@ name: Pre-Commit
 
 on:
   workflow_call:
+    inputs:
+      trivy_scan_ref:
+        description: "Path Trivy scans in the terraform_trivy job. Narrow to e.g. 'terraform' to skip app dependency/Dockerfile scanning."
+        type: string
+        required: false
+        default: "."
 
 env:
   PY_VERSION: "3.x"
@@ -189,6 +195,7 @@ jobs:
         uses: aquasecurity/trivy-action@master
         with:
           scan-type: "fs"
+          scan-ref: ${{ inputs.trivy_scan_ref }}
           hide-progress: false
           exit-code: "1"
           scanners: "vuln,secret,misconfig"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -120,6 +120,15 @@ jobs:
     needs:
       [terraform_fmt, check-yaml, terraform_tflint, terraform_docs]
     steps:
+      # terraform_validate runs `terraform init` in every module directory, and each
+      # one downloads its own copy of the provider plugins (the aws provider alone is
+      # ~700 MB unpacked). On repos with many modules this exhausts the runner's ~14 GB
+      # disk ("no space left on device"). Reclaim space by removing preinstalled
+      # toolchains this job never uses. Purely additive: a no-op for small repos.
+      - name: Free up disk space
+        run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/.ghcup /usr/share/swift
+          df -h /
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:
           go-version: ${{ env.GO_VERSION }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,7 +11,10 @@ on:
 
 env:
   PY_VERSION: "3.x"
-  GO_VERSION: "^1.23.0"
+  # Pinned to 1.23.x, not "^1.23.0": on newer Go the runner resolves to 1.26.x,
+  # where gitleaks' vendored go-re2 wazero runtime panics with
+  # "wasm error: invalid table access" while compiling its config regexes.
+  GO_VERSION: "~1.23.0"
 
 jobs:
   terraform_fmt:

--- a/precommit-config/.tflint.hcl
+++ b/precommit-config/.tflint.hcl
@@ -1,5 +1,12 @@
+# signature = "pgp" pins plugin verification to the legacy PGP key instead of the default
+# "auto", which prefers GitHub attestations. GitHub REST API 2026-03-10 dropped the `bundle`
+# field from attestation list responses; tflint unmarshals the resulting null into a nil
+# *bundle.Bundle without erroring and then panics dereferencing it during `tflint --init`.
+# Upstream: https://github.com/terraform-linters/tflint/issues/2591
+# Drop this line once that lands and the tflint we install carries the fix.
 plugin "aws" {
-    enabled = true
-    version = "0.40.0"
-    source  = "github.com/terraform-linters/tflint-ruleset-aws"
+    enabled   = true
+    version   = "0.40.0"
+    source    = "github.com/terraform-linters/tflint-ruleset-aws"
+    signature = "pgp"
 }


### PR DESCRIPTION
Three fixes to the shared `pre-commit.yml`. The tflint one is an active outage — every repo consuming this workflow is currently failing `terraform_tflint`. The other two have been running in stratusphere via a branch pin since 2026-07-08; this merge retires that pin.

## 1. `fix(tflint)` — unbreak `terraform_tflint` everywhere (urgent)

Not a lint failure: `tflint --init` panics installing the aws plugin, before any linting runs.

```
Installing "aws" plugin...
Panic: runtime error: invalid memory address or nil pointer dereference
 -> 4: github.com/sigstore/sigstore-go/pkg/bundle.(*Bundle).TlogEntries: /bundle.go(300)
 -> 8: github.com/terraform-linters/tflint/plugin.(*SignatureChecker).VerifyAttestations: /signature.go(136)
 -> 9: github.com/terraform-linters/tflint/plugin.(*InstallConfig).Install: /install.go(134)
```

Server-side cause, nothing in our repos changed. GitHub REST API [2026-03-10](https://docs.github.com/en/rest/about-the-rest-api/breaking-changes?apiVersion=2026-03-10) removed the `bundle` field from attestation list responses. tflint calls that endpoint to verify the plugin, and:

1. GitHub now returns `"bundle": null`
2. tflint unmarshals `null` into a `**Bundle` — sets the pointer nil and returns **no error**, so its own nil guard at `plugin/signature.go:133` never fires
3. `verifier.Verify(b, policy)` calls a method on the nil receiver; sigstore-go`s nil check dereferences it. Panic.

A latent tflint bug that only fires once the server returns null. Upstream [terraform-linters/tflint#2591](https://github.com/terraform-linters/tflint/issues/2591) — filed 2026-07-16, still open, `master` unpatched.

`signature = "pgp"` takes the legacy PGP verification path instead of the default `auto` (which prefers attestations). **Verification stays enabled.** tflint emits a deprecation warning about the legacy key; the hook passes. `v0.40.0` ships `checksums.txt.sig`, so the PGP path is valid for the pinned version.

Alternatives ruled out:
- **Pinning older tflint** — trigger is server-side; every version taking the attestation path panics. Confirmed on v0.62.1 and v0.63.1.
- **Bumping sigstore-go** — v1.2.2 has the identical nil-receiver line. Must be fixed tflint-side.
- **`signature = "none"`** — works but disables verification. Avoided; PGP works.

Verified by reproducing the exact CI panic locally, then confirming the fix against a clean plugin dir on tflint v0.63.1 with an authenticated `GITHUB_TOKEN`:

```
Installing "aws" plugin...
The plugin was signed using a legacy PGP signing key. Please update the plugin to the latest version
Installed "aws" (source: github.com/terraform-linters/tflint-ruleset-aws, version: 0.40.0)
+ ruleset.aws (0.40.0)
```

Confirmed green in stratusphere CI: `Terraform validate with tflint...Passed`.

## 2. `fix(terraform_validate)` — free disk before per-module init

`terraform_validate` runs `terraform init` in every module directory, each downloading its own provider copies (aws provider alone is ~700 MB unpacked). Repos with many modules exhaust the runner`s ~14 GB disk with `no space left on device`. Removes preinstalled toolchains the job never uses (android, dotnet, ghc, swift). Purely additive — a no-op for small repos.

## 3. `feat(pre-commit)` — `trivy_scan_ref` input

Adds an optional input to scope the `terraform_trivy` fs scan. Defaults to `"."`, so **existing callers are unaffected**. Callers can pass a narrower path (e.g. `terraform`) to limit the scan to IaC and skip app dependency CVE / Dockerfile findings handled elsewhere.

## Notes for reviewers

- The `Checkout precommit config` step has **no `ref:`**, so config is always read from this repo`s default branch — pinning the reusable workflow to a feature branch does not change which config CI uses. That is why the tflint fix has to land on `main` to take effect anywhere.
- Supersedes #106, which carried the tflint fix alone; closed in favor of this.
- Once merged, stratusphere drops its branch pin (`@fix/tf-validate-free-disk` → `@main`) and deletes its stopgap local `.tflint.hcl`.
- Worth a follow-up: every `--only` rule in the tflint hook is a bundled `terraform_*` rule — no aws-ruleset rule is enabled. The aws plugin install is dead weight and the sole reason this failure mode can hit us. Dropping it would remove the class entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)